### PR TITLE
Consumer throws errors for body/cookie decoder

### DIFF
--- a/examples/consumer.js
+++ b/examples/consumer.js
@@ -63,8 +63,8 @@ function app(app) {
 }
 
 var server = connect.createServer(
-    connect.bodyDecoder(),
-    connect.cookieDecoder(),
+    connect.bodyParser(),
+    connect.cookieParser(),
     connect.session({secret: 'change-me'}),
     connect.router(app),
     connect.errorHandler({ dumpExceptions: true, showStack: true })


### PR DESCRIPTION
It's been changed for the latest connect package.

I fixed these lines:

```
connect.bodyParser(),
connect.cookieParser(),
```
